### PR TITLE
upgrade to CLDR v28

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -20,4 +20,4 @@ repository.type = git
 [Prereqs]
 Mojolicious = 4.71
 Time::Piece = 0
-CLDR::Number = 0.11
+CLDR::Number = 0.13

--- a/t/currency.t
+++ b/t/currency.t
@@ -34,7 +34,7 @@ my %tests = (
     en    => '€9.99',
     es    => "9,99\x{a0}€",
     es_MX => "EUR\x{a0}9.99",
-    zh_CN => '€ 9.99',
+    zh_CN => '€9.99',
 );
 
 for my $lang ( sort keys %tests ) {


### PR DESCRIPTION
This fixes one test that was broken by the new CLDR v28 data, as provided in CLDR::Number v0.13.